### PR TITLE
Dependency requirements, settings, and api additions for IPDetails

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,0 +1,3 @@
+Django==1.8.4
+requests==2.6.2
+djangorestframework==3.1.1

--- a/api_test/api/urls.py
+++ b/api_test/api/urls.py
@@ -3,6 +3,6 @@ from rest_framework import routers
 from .views import IPDetailsView, Traffic
 
 urlpatterns = patterns('api_test.api.views',
-    url(r'/threat/ip/(?P<ip>.*)$', IPDetailsView.as_view(), name='api_threat_details'),
-    url(r'/traffic$', Traffic.as_view(), namespace='api_traffic')
+    url(r'threat/ip/(?P<ip>.*)$', IPDetailsView.as_view(), name='threat_details'),
+    url(r'traffic$', Traffic.as_view(), name='traffic')
 )

--- a/api_test/api/views.py
+++ b/api_test/api/views.py
@@ -1,0 +1,30 @@
+import time
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+from rest_framework import status
+
+from api_test.datastore import IPDetails, DetailsSerializer
+        
+class IPDetailsView(APIView):
+    def get(self, request, *args, **kw):
+        print "in ip details view"
+        # look for ip from request path, if not then try GET param
+        ip = args.get("ip", request.GET.get("ip", None))
+        try:
+            [int(x) for x in ip.split('.')]
+        except:
+            return Response("invalid IP")
+        
+        details_request = IPDetails(ip, *args, **kw)
+
+        result = DetailsSerializer(details_request)
+        response = Response(result.data, status=status.HTTP_200_OK)
+        print "returning response"
+        return response
+
+        
+class Traffic(APIView):
+    def get(self, request, *args, **kw):
+        return Response("Feature Disabled")

--- a/api_test/settings.py
+++ b/api_test/settings.py
@@ -37,7 +37,8 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'api_test.api'
+    'api_test.api',
+    'api_test.datastore'
 )
 
 MIDDLEWARE_CLASSES = (

--- a/api_test/threat.py
+++ b/api_test/threat.py
@@ -4,6 +4,8 @@ import re
 import calendar
 import time
 
+from api_test.datastore import Reputation
+
 # Known bad: 69.43.161.174
 # Known good: 8.8.8.8
 # Find more examples at https://www.alienvault.com/open-threat-exchange/dashboard

--- a/api_test/urls.py
+++ b/api_test/urls.py
@@ -1,9 +1,9 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from server import APIRoot
+from .views import APIRoot
 
 urlpatterns = [
     url(r'^$', APIRoot.as_view(), name='root'),
 
-    url(r'^api/', include('api.urls', namespace="api"))
+    url(r'^api/', include('api_test.api.urls', namespace="api"))
 ]

--- a/api_test/views.py
+++ b/api_test/views.py
@@ -2,28 +2,13 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework import status
-from threat import *
-from serializers import *
+from django.http import HttpResponseRedirect
 import time
-
+import requests
 
 class APIRoot(APIView):
     def get(self, request):
+        ip = request.GET.get('ip', '')
         return Response({
-            'IP Details': reverse('threat_details', request=request),
+            'IP Details': reverse('api:threat_details', kwargs={'ip': ip}),
         })
-
-        
-class IPDetailsView(APIView):
-    def get(self, request, *args, **kw):
-        ip = "1.2.3.4" # TODO: get ip from the url e.g. /api/threat/ip/1.2.3.4
-        
-        details_request = IPDetails(ip, *args, **kw)
-
-        result = DetailsSerializer(details_request)
-        response = Response(result.data, status=status.HTTP_200_OK)
-
-        return response
-
-        
-# TODO: View for /api/traffic


### PR DESCRIPTION
This PR adds in dependency requirements, fixed urls.py routing, and abstracted api methods inside the api module.
Requires work done in the datastore_work branch that populates the datastore module with imported models